### PR TITLE
Add option to save toggle state

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@
       </div>
     </div>
 
-    <div class="relative h-full max-w-5xl mx-auto px-4">
-      <section class="mt-16">
+    <div class="flex justify-center relative h-full max-w-5xl mx-auto px-4">
+      <section class="mt-16 grid grid-cols-2 gap-4">
         <div data-controller="reveal">
           <button
             id="toggle-button"
@@ -132,7 +132,7 @@
           <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hey 👋</p>
         </div>
 
-        <div data-controller="reveal" class="mt-4">
+        <div data-controller="reveal">
           <button
             id="toggle-button"
             data-action="click->reveal#hide"
@@ -142,10 +142,10 @@
             Hide me!
           </button>
 
-          <p id="toggle-target" data-reveal-target="item" class="mt-4">Hey 🙈</p>
+          <p id="toggle-target" data-reveal-target="item">Hey 🙈</p>
         </div>
 
-        <div data-controller="reveal" class="mt-4">
+        <div data-controller="reveal">
           <button
             id="toggle-button"
             data-action="click->reveal#show"
@@ -156,6 +156,15 @@
           </button>
 
           <p id="toggle-target" data-reveal-target="item" class="hidden mt-4">Hi 🐵</p>
+        </div>
+
+        <div data-controller="reveal">
+          <button id="toggle-button" data-action="click->reveal#toggle" type="button"
+            class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow">
+            Save me!
+          </button>
+        
+          <p id="toggle-target" data-reveal-target="item" data-reveal-store-id="unique-ID" class="hidden mt-4">Hey 👀</p>
         </div>
       </section>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,28 @@ export default class Reveal extends Controller {
 
   connect(): void {
     this.class = this.hasHiddenClass ? this.hiddenClass : "hidden"
+    this.restoreState()
   }
 
   toggle(): void {
     this.itemTargets.forEach((item) => {
       item.classList.toggle(this.class)
+      this.saveState(item)
+    })
+  }
+
+  saveState(item: HTMLElement): void {
+    if (!item.dataset.revealStoreId) return
+    const isHidden = item.classList.contains(this.class)
+    sessionStorage.setItem(`reveal-${item.dataset.revealStoreId}`, isHidden ? "false" : "true")
+  }
+
+  restoreState() {
+    this.itemTargets.forEach((item) => {
+      const storedValue = sessionStorage.getItem(`reveal-${item.dataset.revealStoreId}`)
+      if (!storedValue) return
+      const shouldHide = storedValue === "false"
+      item.classList.toggle(this.class, shouldHide)
     })
   }
 


### PR DESCRIPTION
### On the `Reveal` class:

- Create new function to save the state of a certain item on the session storage.
- Save function is always called on `toggle()`
- If `data-reveal-store-id` is empty, return null
- On `connect()` call `restoreState()`
- On `restoreState()` if there's no save state, return null

### On the Landing page

- Create new example button
- Create a grid to center all examples
![image](https://github.com/stimulus-components/stimulus-reveal-controller/assets/65386766/72b4abd6-a90b-4f75-9b99-4c0e1dff9fb0)

If you have any suggestions, please tell me!